### PR TITLE
Fix the incremental task "test"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,11 @@ pluginBundle {
     tags = ['soramitsu', 'gradle']
 }
 
+test {
+    def projectsDir = "$project.projectDir/projects"
+    inputs.files fileTree(dir: projectsDir, exclude: '**/.gradle')
+}
+
 test.dependsOn(install)
 
 testlogger {


### PR DESCRIPTION
Hello

This commit enhances the incremental task "test".

Specifically, this tasks runs the tests of the project. However, some tests depend on the projects found in the `projects` directory of this project.

For example, see this [test](https://github.com/soramitsu/gradle-sora-plugin/blob/master/src/test/groovy/jp/co/soramitsu/devops/project/JavaPluginTasksTest.groovy)

This commit adds the right inputs for the "test" task so that if there is any change in those files, the incremental task "test" is triggered correctly.