### PR TITLE
[DOPS-893] Add task printDockerImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ https://plugins.gradle.org/plugin/jp.co.soramitsu.sora-plugin
 | printOsInfo      | printOsInfo                      | Prints information about OS and project                 |
 | printVersion     | printVersion                     | Prints project version based on git                     |
 | printConfig      | printConfig                      | Prints plugin configuration                             |
+| printDockerImage | printDockerImage                 | Prints Docker Image that will be used in dockerPush     |
 | dockerVersion    | dockerVersion                    | Prints current docker version                           |
 | dockerClean      | dockerClean                      | Cleans docker build context (build/docker)              |
 | dockerfileCreate | dockerClean + dockerfileCreate   | Generates Dockerfile in build context                   |

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group 'jp.co.soramitsu'
 def pluginId = "${group}.sora-plugin"
-version System.getenv('PLUGIN_VERSION') ?: "0.1.4"
+version System.getenv('PLUGIN_VERSION') ?: "0.1.5"
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/jp/co/soramitsu/devops/SoraTask.groovy
+++ b/src/main/groovy/jp/co/soramitsu/devops/SoraTask.groovy
@@ -24,6 +24,7 @@ class SoraTask {
     public static final String printOsInfo = "printOsInfo"
     public static final String printVersion = "printVersion"
     public static final String printConfig = "printConfig"
+    public static final String printDockerImage = "printDockerImage"
 
     /// coverage
     public static final String coverage = "coverage"

--- a/src/main/groovy/jp/co/soramitsu/devops/misc/InfoPlugin.groovy
+++ b/src/main/groovy/jp/co/soramitsu/devops/misc/InfoPlugin.groovy
@@ -85,7 +85,7 @@ class InfoPlugin implements Plugin<Project> {
     docker.projectName   = ${project.name}
     docker.ImageName     = ${parts}
     docker.tag           = ${tag}
-    docker.fullImageName = ${parts}:$tag
+    docker.fullImageName = ${parts}:${tag}
 """)
             }
         }

--- a/src/main/groovy/jp/co/soramitsu/devops/misc/InfoPlugin.groovy
+++ b/src/main/groovy/jp/co/soramitsu/devops/misc/InfoPlugin.groovy
@@ -10,6 +10,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 
+import java.util.stream.Collectors
+
 class InfoPlugin implements Plugin<Project> {
 
     static final String INFO_GROUP_NAME = "info"
@@ -83,7 +85,7 @@ class InfoPlugin implements Plugin<Project> {
     docker.registry      = ${registry?.url}
     docker.projectGroup  = ${project.extensions.getByType(SoramitsuExtension)?.projectGroup}
     docker.projectName   = ${project.name}
-    docker.ImageName     = ${parts}
+    docker.imageName     = ${parts}
     docker.tag           = ${tag}
     docker.fullImageName = ${parts}:${tag}
 """)


### PR DESCRIPTION
For complicated CI we need to know the docker image name that dockerPush task will use to push docker image.
This pr adds task printDockerImage.
